### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,27 +93,27 @@ Further documentation can be found on `Read the Docs`_.
     :scale: 100%
     :target: http://olimex-ekg-emg.readthedocs.org/en/latest/
 
-.. |downloads| image:: https://pypip.in/download/olimex-ekg-emg/badge.svg?period=month
+.. |downloads| image:: https://img.shields.io/pypi/dm/olimex-ekg-emg.svg
     :target: https://pypi.python.org/pypi/olimex-ekg-emg
     :alt: Downloads
 
-.. |latest| image:: https://pypip.in/version/olimex-ekg-emg/badge.svg?text=version
+.. |latest| image:: https://img.shields.io/pypi/v/olimex-ekg-emg.svg?label=version
     :target: https://pypi.python.org/pypi/olimex-ekg-emg/
     :alt: Latest Version
 
-.. |versions| image:: https://pypip.in/py_versions/olimex-ekg-emg/badge.svg
+.. |versions| image:: https://img.shields.io/pypi/pyversions/olimex-ekg-emg.svg
     :target: https://pypi.python.org/pypi/olimex-ekg-emg/
     :alt: Supported Python versions
 
-.. |implementations| image:: https://pypip.in/implementation/olimex-ekg-emg/badge.svg
+.. |implementations| image:: https://img.shields.io/pypi/implementation/olimex-ekg-emg.svg
     :target: https://pypi.python.org/pypi/olimex-ekg-emg/
     :alt: Supported Python implementations
 
-.. |dev_status| image:: https://pypip.in/status/olimex-ekg-emg/badge.svg
+.. |dev_status| image:: https://img.shields.io/pypi/status/olimex-ekg-emg.svg
     :target: https://pypi.python.org/pypi/olimex-ekg-emg/
     :alt: Development Status
 
-.. |license| image:: https://pypip.in/license/olimex-ekg-emg/badge.svg
+.. |license| image:: https://img.shields.io/pypi/l/olimex-ekg-emg.svg
     :target: https://pypi.python.org/pypi/olimex-ekg-emg/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20olimex-ekg-emg))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `olimex-ekg-emg`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.